### PR TITLE
Fix pager command argument stripping and add comprehensive tests

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -224,12 +224,8 @@ fn get_pager_from_env() -> Option<String> {
                 // Replace problematic pagers with "less"
                 Some("less".to_string())
             } else {
-                // Preserve the full command including arguments
-                if args.is_empty() {
-                    Some(bin.to_string())
-                } else {
-                    Some(format!("{} {}", bin, args.join(" ")))
-                }
+                // Preserve the original command string unmodified to maintain proper quoting
+                Some(cmd.to_string())
             }
         } else {
             Some("less".to_string())

--- a/src/env.rs
+++ b/src/env.rs
@@ -132,7 +132,7 @@ pub mod tests {
         drop(_guard);
         assert_eq!(
             env.pagers.1,
-            Some("/bin/sh -c head -10000 | cat".into()),
+            Some("/bin/sh -c \"head -10000 | cat\"".into()),
             "Complex shell pager command should be preserved with arguments"
         );
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 
 const COLORTERM: &str = "COLORTERM";
 const BAT_THEME: &str = "BAT_THEME";
@@ -40,11 +41,11 @@ impl DeltaEnv {
         let current_dir = env::current_dir().ok();
         let pagers = (
             env::var(DELTA_PAGER).ok(),
-            // We're using `bat::config::get_pager_executable` here instead of just returning
-            // the pager from the environment variables, because we want to make sure
-            // that the pager is a valid pager from env and handle the case of
-            // the PAGER being set to something invalid like "most" and "more".
-            bat::config::get_pager_executable(None),
+            // Reimplement bat's pager detection logic to preserve full PAGER commands.
+            // This fixes the bug where bat::config::get_pager_executable(None) was stripping
+            // arguments from complex PAGER commands like '/bin/sh -c "head -10000 | cat"'.
+            // We can't use bat::pager::get_pager directly because the pager module is private.
+            get_pager_from_env(),
         );
 
         Self {
@@ -83,6 +84,7 @@ pub mod tests {
         let feature = "Awesome Feature";
         env::set_var("DELTA_FEATURES", feature);
         let env = DeltaEnv::init();
+        drop(_guard);
         assert_eq!(env.features, Some(feature.into()));
         // otherwise `current_dir` is not used in the test cfg:
         assert_eq!(env.current_dir, env::current_dir().ok());
@@ -93,6 +95,7 @@ pub mod tests {
         let _guard = ENV_ACCESS.lock().unwrap();
         env::set_var("PAGER", "bat");
         let env = DeltaEnv::init();
+        drop(_guard);
         assert_eq!(
             env.pagers.1,
             Some("bat".into()),
@@ -106,6 +109,7 @@ pub mod tests {
         let _guard = ENV_ACCESS.lock().unwrap();
         env::set_var("PAGER", "more");
         let env = DeltaEnv::init();
+        drop(_guard);
         assert_eq!(env.pagers.1, Some("less".into()));
     }
 
@@ -114,6 +118,123 @@ pub mod tests {
         let _guard = ENV_ACCESS.lock().unwrap();
         env::set_var("PAGER", "most");
         let env = DeltaEnv::init();
+        drop(_guard);
         assert_eq!(env.pagers.1, Some("less".into()));
+    }
+
+    #[test]
+    fn test_env_parsing_with_complex_shell_pager_command() {
+        // This test verifies the core bug fix: complex PAGER commands with arguments
+        // should be preserved, not stripped down to just the executable path.
+        let _guard = ENV_ACCESS.lock().unwrap();
+        env::set_var("PAGER", "/bin/sh -c \"head -10000 | cat\"");
+        let env = DeltaEnv::init();
+        drop(_guard);
+        assert_eq!(
+            env.pagers.1,
+            Some("/bin/sh -c head -10000 | cat".into()),
+            "Complex shell pager command should be preserved with arguments"
+        );
+    }
+
+    #[test]
+    fn test_env_parsing_with_simple_shell_pager_command() {
+        let _guard = ENV_ACCESS.lock().unwrap();
+        env::set_var("PAGER", "/bin/sh -c \"cat\"");
+        let env = DeltaEnv::init();
+        drop(_guard);
+        assert_eq!(
+            env.pagers.1,
+            Some("/bin/sh -c cat".into()),
+            "Simple shell pager command should be preserved with arguments"
+        );
+    }
+
+    #[test]
+    fn test_env_parsing_with_pager_arguments_preserved() {
+        // Test that pager commands with various argument styles are preserved
+        let _guard = ENV_ACCESS.lock().unwrap();
+        env::set_var("PAGER", "less -R -F -X");
+        let env = DeltaEnv::init();
+        drop(_guard);
+        assert_eq!(
+            env.pagers.1,
+            Some("less -R -F -X".into()),
+            "Pager arguments should be preserved"
+        );
+    }
+
+    #[test]
+    fn test_env_parsing_delta_pager_takes_precedence() {
+        // Test that DELTA_PAGER takes precedence over PAGER
+        let _guard = ENV_ACCESS.lock().unwrap();
+        env::set_var("PAGER", "cat");
+        env::set_var("DELTA_PAGER", "/bin/sh -c \"head -1 | cat\"");
+        let env = DeltaEnv::init();
+        drop(_guard);
+        assert_eq!(
+            env.pagers.0,
+            Some("/bin/sh -c \"head -1 | cat\"".into()),
+            "DELTA_PAGER should be preserved exactly as set"
+        );
+        assert_eq!(
+            env.pagers.1,
+            Some("cat".into()),
+            "PAGER should also be preserved for fallback"
+        );
+    }
+}
+
+/// Get pager from environment variables using bat's logic.
+/// This reimplements bat's pager::get_pager function to preserve full PAGER commands
+/// including arguments, while still handling problematic pagers properly.
+fn get_pager_from_env() -> Option<String> {
+    let bat_pager = env::var("BAT_PAGER");
+    let pager = env::var("PAGER");
+
+    let (cmd, from_pager_env) = match (&bat_pager, &pager) {
+        (Ok(bat_pager), _) => (bat_pager.as_str(), false),
+        (_, Ok(pager)) => (pager.as_str(), true),
+        _ => ("less", false),
+    };
+
+    // Parse the command using shell_words to split into binary and arguments
+    if let Ok(parts) = shell_words::split(cmd) {
+        if let Some((bin, args)) = parts.split_first() {
+            // Determine what kind of pager this is
+            let pager_bin = Path::new(bin).file_stem();
+            let current_bin = env::args_os().next();
+
+            let is_current_bin_pager = current_bin
+                .map(|s| Path::new(&s).file_stem() == pager_bin)
+                .unwrap_or(false);
+
+            let is_problematic_pager = if from_pager_env {
+                // Only replace problematic pagers when they come from PAGER env var
+                match pager_bin.map(|s| s.to_string_lossy()).as_deref() {
+                    Some("more") | Some("most") => true,
+                    _ if is_current_bin_pager => true, // Prevent recursion
+                    _ => false,
+                }
+            } else {
+                false
+            };
+
+            if is_problematic_pager {
+                // Replace problematic pagers with "less"
+                Some("less".to_string())
+            } else {
+                // Preserve the full command including arguments
+                if args.is_empty() {
+                    Some(bin.to_string())
+                } else {
+                    Some(format!("{} {}", bin, args.join(" ")))
+                }
+            }
+        } else {
+            Some("less".to_string())
+        }
+    } else {
+        Some("less".to_string())
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -145,7 +145,7 @@ pub mod tests {
         drop(_guard);
         assert_eq!(
             env.pagers.1,
-            Some("/bin/sh -c cat".into()),
+            Some("/bin/sh -c \"cat\"".into()),
             "Simple shell pager command should be preserved with arguments"
         );
     }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,7 @@
 pub mod ansi_test_utils;
 pub mod integration_test_utils;
-pub mod test_example_diffs;
 pub mod test_pager_integration;
+pub mod test_example_diffs;
 pub mod test_utils;
 
 #[cfg(not(test))]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,7 +1,7 @@
 pub mod ansi_test_utils;
 pub mod integration_test_utils;
-pub mod test_pager_integration;
 pub mod test_example_diffs;
+pub mod test_pager_integration;
 pub mod test_utils;
 
 #[cfg(not(test))]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,7 @@
 pub mod ansi_test_utils;
 pub mod integration_test_utils;
 pub mod test_example_diffs;
+pub mod test_pager_integration;
 pub mod test_utils;
 
 #[cfg(not(test))]

--- a/src/tests/test_pager_integration.rs
+++ b/src/tests/test_pager_integration.rs
@@ -1,0 +1,53 @@
+#![cfg(test)]
+
+use std::env;
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+#[test]
+fn test_pager_integration_with_complex_command() {
+    // This test demonstrates a bug where complex PAGER commands with arguments
+    // cause "command not found" errors because bat::config::get_pager_executable
+    // strips the arguments, leaving only the executable path.
+
+    env::set_var("PAGER", "/bin/sh -c \"head -10000 | cat\"");
+
+    // Run delta as a subprocess with paging enabled - this will spawn the actual pager
+    let mut delta_cmd = Command::new("cargo")
+        .args(&["run", "--bin", "delta", "--", "--paging=always"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("delta to start successfully");
+
+    // Send test input to delta
+    if let Some(stdin) = delta_cmd.stdin.as_mut() {
+        stdin
+            .write_all(b"line1\nline2\nline3\nline4\nline5\n")
+            .unwrap();
+    }
+
+    // Wait for delta to complete and capture output
+    let output = delta_cmd
+        .wait_with_output()
+        .expect("delta to finish and produce output");
+
+    // Clean up environment variable
+    env::remove_var("PAGER");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // The bug: when bat strips arguments from "/bin/sh -c \"head -10000 | cat\""
+    // to just "/bin/sh", the shell tries to execute each input line as a command,
+    // resulting in "command not found" errors in stderr
+    assert!(
+        !stderr.contains("command not found"),
+        "Pager integration failed: 'command not found' errors in stderr indicate that \
+         bat::config::get_pager_executable stripped arguments from the PAGER command. \
+         Stderr: {}\nStdout: {}",
+        stderr,
+        stdout
+    );
+}

--- a/src/tests/test_pager_integration.rs
+++ b/src/tests/test_pager_integration.rs
@@ -18,9 +18,8 @@ fn test_pager_integration_with_complex_command() {
     let _env_guard = EnvVarGuard::new("PAGER", "/bin/sh -c \"head -10000 | cat\"");
 
     // Run delta as a subprocess with paging enabled - this will spawn the actual pager
-    let delta_path = env!("CARGO_BIN_EXE_delta");
-    let mut delta_cmd = Command::new(delta_path)
-        .args(&["--paging=always"])
+    let mut delta_cmd = Command::new("cargo")
+        .args(&["run", "--bin", "delta", "--", "--paging=always"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src/tests/test_pager_integration.rs
+++ b/src/tests/test_pager_integration.rs
@@ -18,8 +18,9 @@ fn test_pager_integration_with_complex_command() {
     let _env_guard = EnvVarGuard::new("PAGER", "/bin/sh -c \"head -10000 | cat\"");
 
     // Run delta as a subprocess with paging enabled - this will spawn the actual pager
-    let mut delta_cmd = Command::new("cargo")
-        .args(&["run", "--bin", "delta", "--", "--paging=always"])
+    let delta_path = env!("CARGO_BIN_EXE_delta");
+    let mut delta_cmd = Command::new(delta_path)
+        .args(&["--paging=always"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())


### PR DESCRIPTION
- Replace bat::config::get_pager_executable with custom get_pager_from_env() to preserve full PAGER commands including arguments
- Add failing integration test demonstrating the bug where complex PAGER commands like '/bin/sh -c "head -10000 | cat"' get stripped to '/bin/sh'
- Add unit tests covering various pager scenarios:
  * Complex shell commands with arguments
  * Simple pager commands with flags
  * DELTA_PAGER precedence over PAGER
  * Problematic pager replacement (more/most -> less)
- Fix mutex poisoning in tests by using explicit drop() to release locks before assertions

Fixes issue where bat::config::get_pager_executable was stripping arguments from complex pager commands, causing shell to execute input lines as commands instead of passing them through the intended pipeline.